### PR TITLE
Ребаланс стаканчиков

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -74,7 +74,7 @@
   - type: SolutionContainerManager
     solutions:
       drink:
-        maxVol: 10 # SIS-Water Cup Rebalance
+        maxVol: 10 # SIS-Rebalance_Water_Cup
   - type: Item
     size: Tiny
   - type: Sprite


### PR DESCRIPTION
## Описание PR
Стаканчики из кулера теперь вмещают 10 унций вместо 5.

## Почему / Баланс
Предложка с кучей лайков

## Технические детали
Прототипы

## Медиа

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [x] Я добавил медиафайлы (скрины, видео) к этому PR или он не требует демонстрации в игре.
- [x] Я проверил что мои изменения не вызывают конфликтов и багов в сборке.
- [x] Я уверен, что мои изменения не нарушают лицензионные соглашения.

**Список изменений**
<!--
Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
Убедитесь, что вы прочитали рекомендации и вынесли этот шаблон Changelog ниже блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl: и пинг для Discord, если участвовало больше одного человека то разделять ники через символ "/". (например :cl: @shegare / @liem.98 / @samur7).
Также список должен идти сверху вниз, сгруппировано и следуя иерархии (сначала сгруппировано только апстримы, потом сгруппировано только админ изменения и т.п.).
В случае пропуска писать N/A.
-->

:cl: @Higertas
- :gear: Изменена вместимость стаканчиков из кулера с 5 унций, до 10.


